### PR TITLE
Cleaner event querying for get/delete

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check-types": "7.0.1",
     "got": "6.6.3",
     "lodash.defaultsdeep": "4.6.0",
+    "lodash.includes": "4.3.0",
     "lodash.pickby": "4.6.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "check-types": "7.0.1",
     "got": "6.6.3",
     "lodash.defaultsdeep": "4.6.0",
-    "lodash.difference": "4.5.0"
+    "lodash.pickby": "4.6.0"
   },
   "devDependencies": {
     "chai": "^3.3.0",

--- a/spec/events.spec.js
+++ b/spec/events.spec.js
@@ -25,18 +25,24 @@ describe('events', function() {
     it('should get a single event', function*() {
         const event = generateFakeEvent();
         function _payload() {
-            return event;
+            return {
+                pages: {
+                    previous: null,
+                    next: null
+                },
+                data: [event]
+            };
         }
 
         function _validate(options) {
-            expect(options.url).to.equal(`/v1/apps/1337/events/${event.id}`);
+            expect(options.url).to.equal(`/v1/apps/1337/events?id=${event.id}`);
             expect(options.method).to.be.oneOf([undefined, 'GET']);
             expect(options.headers).to.be.an('object');
         }
 
-        const result = yield bup.events.get(event.id, { _payload, _validate });
+        const result = yield bup.events.query({ id: event.id }).getList({ _payload, _validate });
 
-        expect(result).to.be.an('object');
+        expect(result).to.be.an('array');
     });
 
     it('should get all events', function*() {
@@ -68,13 +74,13 @@ describe('events', function() {
             if (options.url.indexOf('PAGE_TWO') > 0) {
                 expect(options.url).to.equal('/v1/apps/1337/events?after=PAGE_TWO');
             } else {
-                expect(options.url).to.equal('/v1/apps/1337/events');
+                expect(options.url).to.equal('/v1/apps/1337/events?');
             }
             expect(options.headers).to.be.an('object');
         }
 
         let count = 0;
-        for (let event of bup.events.getAll({ _payload, _validate })) {
+        for (let event of bup.events.query().getAll({ _payload, _validate })) {
             count++;
             event = yield event;
             expect(event).to.be.an('object');
@@ -113,7 +119,7 @@ describe('events', function() {
             expect(options.headers).to.be.an('object');
         }
 
-        const result = yield bup.events.remove(event.id, { _payload, _validate });
+        const result = yield bup.events.query({ id: event.id }).remove({ _payload, _validate });
 
         expect(result).to.eql(event);
     });
@@ -129,7 +135,7 @@ describe('events', function() {
             expect(options.headers).to.be.an('object');
         }
 
-        yield bup.events.removeMultiple({ subject: '100' }, { _payload, _validate });
+        yield bup.events.query({ subject: '100' }).remove({ _payload, _validate });
     });
 
     it('should delete multiple events after a specific date', function*() {
@@ -145,7 +151,7 @@ describe('events', function() {
             expect(options.headers).to.be.an('object');
         }
 
-        yield bup.events.removeMultiple({ since: date }, { _payload, _validate });
+        yield bup.events.query({ since: date }).remove({ _payload, _validate });
     });
 
     it('should delete all events', function*() {
@@ -159,6 +165,6 @@ describe('events', function() {
             expect(options.headers).to.be.an('object');
         }
 
-        yield bup.events.removeAll({ _payload, _validate });
+        yield bup.events.query({ all: true }).remove({ _payload, _validate });
     });
 });

--- a/spec/events.spec.js
+++ b/spec/events.spec.js
@@ -40,7 +40,7 @@ describe('events', function() {
             expect(options.headers).to.be.an('object');
         }
 
-        const result = yield bup.events.query({ id: event.id }).getList({ _payload, _validate });
+        const result = yield bup.events.query().id(event.id).getList({ _payload, _validate });
 
         expect(result).to.be.an('array');
     });
@@ -119,7 +119,7 @@ describe('events', function() {
             expect(options.headers).to.be.an('object');
         }
 
-        const result = yield bup.events.query({ id: event.id }).remove({ _payload, _validate });
+        const result = yield bup.events.query().id(event.id).remove({ _payload, _validate });
 
         expect(result).to.eql(event);
     });
@@ -135,7 +135,7 @@ describe('events', function() {
             expect(options.headers).to.be.an('object');
         }
 
-        yield bup.events.query({ subject: '100' }).remove({ _payload, _validate });
+        yield bup.events.query().subject('100').remove({ _payload, _validate });
     });
 
     it('should delete multiple events after a specific date', function*() {
@@ -151,7 +151,7 @@ describe('events', function() {
             expect(options.headers).to.be.an('object');
         }
 
-        yield bup.events.query({ since: date }).remove({ _payload, _validate });
+        yield bup.events.query().since(date).remove({ _payload, _validate });
     });
 
     it('should delete all events', function*() {
@@ -165,6 +165,6 @@ describe('events', function() {
             expect(options.headers).to.be.an('object');
         }
 
-        yield bup.events.query({ all: true }).remove({ _payload, _validate });
+        yield bup.events.query().all(true).remove({ _payload, _validate });
     });
 });

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -48,7 +48,7 @@ class EventQueryBuilder {
     }
 
     until(until) {
-        check.date(until, 'until must be a date');
+        check.date(until, 'until must be a boolean');
         this.until = until.toISOString();
         return this;
     }

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -15,7 +15,9 @@ module.exports = function events(context) {
     // Sets up a delete/get request targeting events using several filters
     // @param queryBy: filters to query events by
     // @returns Returns an object with functions to get or delete queried events
-    function query(queryBy = {}) {
+    function query(queryBy) {
+        // TODO switch to queryBy = {} when we get off of supporting Node v4
+        queryBy = queryBy || {};
         check.object(queryBy, 'queryBy must be an object');
 
         const allowedKeys = ['id', 'key', 'since', 'until', 'subject', 'all'];

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -48,13 +48,13 @@ class EventQueryBuilder {
     }
 
     until(until) {
-        check.date(until, 'until must be a boolean');
+        check.date(until, 'until must be a date');
         this.until = until.toISOString();
         return this;
     }
 
     all(all) {
-        check.boolean(all, 'all must be a date');
+        check.boolean(all, 'all must be a boolean');
         this.all = all;
         return this;
     }

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -8,6 +8,16 @@ const querystring = require('querystring');
 const pageToGenerator = require('../utils/pageToGenerator');
 const ENDPT = 'events';
 
+const GET_QUERY_PARAMS = ['id', 'key', 'subject', 'since', 'until'];
+const DELETE_QUERY_PARAMS = ['id', 'key', 'subject', 'since', 'until', 'all'];
+
+function collectQueryParams(source, keys) {
+    return pickBy(source, function(value, key) {
+        // TODO switch to Array.prototype.includes when we drop support for Node v4
+        return !!value && includes(keys, key);
+    });
+}
+
 class EventQueryBuilder {
     constructor(context) {
         this.context = context;
@@ -53,10 +63,7 @@ class EventQueryBuilder {
     // @param userOpts: option overrides for this request
     // @return A promise that resolves to an array of event objects
     getList(userOpts) {
-        const queryBy = pickBy(this, function(value, key) {
-            // TODO switch to Array.prototype.includes when we drop support for Node v4
-            return !!value && includes(['id', 'key', 'subject', 'since', 'until'], key);
-        });
+        const queryBy = collectQueryParams(this, GET_QUERY_PARAMS);
 
         let array = [];
         let url = `/v1/apps/${this.context.applicationId}/${ENDPT}?${querystring.stringify(queryBy)}`;
@@ -81,10 +88,7 @@ class EventQueryBuilder {
     // @param userOpts: option overrides for this request
     // @return An iterator that returns promises that resolve with the next event
     *getAll(userOpts) {
-        const queryBy = pickBy(this, function(value, key) {
-            // TODO switch to Array.prototype.includes when we drop support for Node v4
-            return !!value && includes(['id', 'key', 'subject', 'since', 'until'], key);
-        });
+        const queryBy = collectQueryParams(this, GET_QUERY_PARAMS);
 
         const pageFn = () => {
             let url = `/v1/apps/${this.context.applicationId}/${ENDPT}?${querystring.stringify(queryBy)}`;
@@ -103,10 +107,7 @@ class EventQueryBuilder {
     // @param userOpts: option overrides for this request
     // @returns Returns a promise that resolves to an object stating the number of deleted events
     remove(userOpts) {
-        const queryBy = pickBy(this, function(value, key) {
-            // TODO switch to Array.prototype.includes when we drop support for Node v4
-            return !!value && includes(['id', 'key', 'subject', 'since', 'until', 'all'], key);
-        });
+        const queryBy = collectQueryParams(this, DELETE_QUERY_PARAMS);
 
         return this.context.http.makeRequest({
             method: 'DELETE',

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -3,6 +3,7 @@
 const check = require('check-types');
 const common = require('./../common');
 const pickBy = require('lodash.pickby');
+const includes = require('lodash.includes');
 const querystring = require('querystring');
 const pageToGenerator = require('../utils/pageToGenerator');
 const ENDPT = 'events';
@@ -53,7 +54,8 @@ class EventQueryBuilder {
     // @return A promise that resolves to an array of event objects
     getList(userOpts) {
         const queryBy = pickBy(this, function(value, key) {
-            return !!value && ['id', 'key', 'subject', 'since', 'until'].includes(key);
+            // TODO switch to Array.prototype.includes when we drop support for Node v4
+            return !!value && includes(['id', 'key', 'subject', 'since', 'until'], key);
         });
 
         let array = [];
@@ -80,7 +82,8 @@ class EventQueryBuilder {
     // @return An iterator that returns promises that resolve with the next event
     *getAll(userOpts) {
         const queryBy = pickBy(this, function(value, key) {
-            return !!value && ['id', 'key', 'subject', 'since', 'until'].includes(key);
+            // TODO switch to Array.prototype.includes when we drop support for Node v4
+            return !!value && includes(['id', 'key', 'subject', 'since', 'until'], key);
         });
 
         const pageFn = () => {
@@ -101,7 +104,8 @@ class EventQueryBuilder {
     // @returns Returns a promise that resolves to an object stating the number of deleted events
     remove(userOpts) {
         const queryBy = pickBy(this, function(value, key) {
-            return !!value && ['id', 'key', 'subject', 'since', 'until', 'all'].includes(key);
+            // TODO switch to Array.prototype.includes when we drop support for Node v4
+            return !!value && includes(['id', 'key', 'subject', 'since', 'until', 'all'], key);
         });
 
         return this.context.http.makeRequest({

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -2,10 +2,114 @@
 
 const check = require('check-types');
 const common = require('./../common');
-const difference = require('lodash.difference');
+const pickBy = require('lodash.pickby');
 const querystring = require('querystring');
 const pageToGenerator = require('../utils/pageToGenerator');
 const ENDPT = 'events';
+
+class EventQueryBuilder {
+    constructor(context) {
+        this.context = context;
+    }
+
+    id(id) {
+        check.string(id, 'id must be a string');
+        this.id = id;
+        return this;
+    }
+
+    key(key) {
+        check.string(key, 'key must be a string');
+        this.key = key;
+        return this;
+    }
+
+    subject(subject) {
+        check.string(subject, 'subject must be a string');
+        this.subject = subject;
+        return this;
+    }
+
+    since(since) {
+        check.date(since, 'since must be a date');
+        this.since = since.toISOString();
+        return this;
+    }
+
+    until(until) {
+        check.date(until, 'until must be a date');
+        this.until = until.toISOString();
+        return this;
+    }
+
+    all(all) {
+        check.boolean(all, 'all must be a date');
+        this.all = all;
+        return this;
+    }
+
+    // retrieve all queried events, returned as an array
+    // @param userOpts: option overrides for this request
+    // @return A promise that resolves to an array of event objects
+    getList(userOpts) {
+        const queryBy = pickBy(this, function(value, key) {
+            return !!value && ['id', 'key', 'subject', 'since', 'until'].includes(key);
+        });
+
+        let array = [];
+        let url = `/v1/apps/${this.context.applicationId}/${ENDPT}?${querystring.stringify(queryBy)}`;
+
+        const pageFn = () => {
+            return this.context.http.makeRequest({ url }, userOpts).then(function(body) {
+                array = array.concat(body.data || []); // concatinate the new data
+
+                url = body.pages.next;
+                if (url) {
+                    return pageFn();
+                } else {
+                    return array;
+                }
+            });
+        };
+
+        return pageFn();
+    }
+
+    // retrieve all queried events, returned as an iterator
+    // @param userOpts: option overrides for this request
+    // @return An iterator that returns promises that resolve with the next event
+    *getAll(userOpts) {
+        const queryBy = pickBy(this, function(value, key) {
+            return !!value && ['id', 'key', 'subject', 'since', 'until'].includes(key);
+        });
+
+        const pageFn = () => {
+            let url = `/v1/apps/${this.context.applicationId}/${ENDPT}?${querystring.stringify(queryBy)}`;
+            return () => {
+                return this.context.http.makeRequest({ url }, userOpts).then(function(body) {
+                    url = body.pages.next;
+                    return body;
+                });
+            };
+        };
+
+        yield* pageToGenerator(pageFn());
+    }
+
+    // delete all queried events
+    // @param userOpts: option overrides for this request
+    // @returns Returns a promise that resolves to an object stating the number of deleted events
+    remove(userOpts) {
+        const queryBy = pickBy(this, function(value, key) {
+            return !!value && ['id', 'key', 'subject', 'since', 'until', 'all'].includes(key);
+        });
+
+        return this.context.http.makeRequest({
+            method: 'DELETE',
+            url: `/v1/apps/${this.context.applicationId}/${ENDPT}?${querystring.stringify(queryBy)}`
+        }, userOpts);
+    }
+}
 
 // Events module
 // @param context: The context to make requests in. Basically, `this`
@@ -14,83 +118,9 @@ module.exports = function events(context) {
 
     // Sets up a delete/get request targeting events using several filters
     // @param queryBy: filters to query events by
-    // @returns Returns an object with functions to get or delete queried events
-    function query(queryBy) {
-        // TODO switch to queryBy = {} when we get off of supporting Node v4
-        queryBy = queryBy || {};
-        check.object(queryBy, 'queryBy must be an object');
-
-        const allowedKeys = ['id', 'key', 'since', 'until', 'subject', 'all'];
-        const unallowedKeys = difference(Object.keys(queryBy), allowedKeys);
-
-        if (unallowedKeys.length > 0) {
-            throw new Error('Unallowed keys: ' + unallowedKeys);
-        }
-
-        // convert dates
-        if (check.date(queryBy.since)) {
-            queryBy.since = queryBy.since.toISOString();
-        }
-
-        if (check.date(queryBy.until)) {
-            queryBy.until = queryBy.until.toISOString();
-        }
-
-        return {
-            // retrieve all queried events, returned as an array
-            // @param userOpts: option overrides for this request
-            // @return A promise that resolves to an array of event objects
-            getList: function(userOpts) {
-                // Doesn't apply for get
-                delete queryBy.all;
-
-                let array = [];
-                let url = `/v1/apps/${context.applicationId}/${ENDPT}?${querystring.stringify(queryBy)}`;
-
-                function pageFn() {
-                    return context.http.makeRequest({ url }, userOpts).then(function(body) {
-                        array = array.concat(body.data || []); // concatinate the new data
-
-                        url = body.pages.next;
-                        if (url) {
-                            return pageFn();
-                        } else {
-                            return array;
-                        }
-                    });
-                }
-
-                return pageFn();
-            },
-            // retrieve all queried events, returned as an iterator
-            // @param userOpts: option overrides for this request
-            // @return An iterator that returns promises that resolve with the next event
-            getAll: function*(userOpts) {
-                // Doesn't apply for get
-                delete queryBy.all;
-
-                function pageFn() {
-                    let url = `/v1/apps/${context.applicationId}/${ENDPT}?${querystring.stringify(queryBy)}`;
-                    return function() {
-                        return context.http.makeRequest({ url }, userOpts).then(function(body) {
-                            url = body.pages.next;
-                            return body;
-                        });
-                    };
-                }
-
-                yield* pageToGenerator(pageFn());
-            },
-            // delete all queried events
-            // @param userOpts: option overrides for this request
-            // @returns Returns a promise that resolves to an object stating the number of deleted events
-            remove: function(userOpts) {
-                return context.http.makeRequest({
-                    method: 'DELETE',
-                    url: `/v1/apps/${context.applicationId}/${ENDPT}?${querystring.stringify(queryBy)}`
-                }, userOpts);
-            }
-        };
+    // @returns Returns an instance of the EventQueryBuilder class
+    function query() {
+        return new EventQueryBuilder(context);
     }
 
     return {

--- a/src/events/index.js
+++ b/src/events/index.js
@@ -4,6 +4,7 @@ const check = require('check-types');
 const common = require('./../common');
 const difference = require('lodash.difference');
 const querystring = require('querystring');
+const pageToGenerator = require('../utils/pageToGenerator');
 const ENDPT = 'events';
 
 // Events module
@@ -11,65 +12,87 @@ const ENDPT = 'events';
 module.exports = function events(context) {
     const obj = common(context, ENDPT);
 
-    // deletes an event by ID
-    // @param id
-    // @param userOpts: option overrides for this request
-    // @returns Returns a promise that resolves to the deleted object
-    function remove(id, userOpts) {
-        check.string(id, 'id must be a string');
+    // Sets up a delete/get request targeting events using several filters
+    // @param queryBy: filters to query events by
+    // @returns Returns an object with functions to get or delete queried events
+    function query(queryBy = {}) {
+        check.object(queryBy, 'queryBy must be an object');
 
-        return context.http.makeRequest({
-            method: 'DELETE',
-            url: `/v1/apps/${context.applicationId}/${ENDPT}?id=${id}`
-        }, userOpts);
-    }
-
-    // deletes multiple events
-    // @param deleteBy: options to delete events by
-    // @param userOpts: option overrides for this request
-    // @returns Returns a promise that resolves to an object stating the number of deleted events
-    function removeMultiple(deleteBy, userOpts) {
-        check.string(deleteBy, 'deleteBy must be an object');
-
-        const allowedKeys = ['id', 'since', 'until', 'subject', 'key'];
-        const unallowedKeys = difference(Object.keys(deleteBy), allowedKeys);
+        const allowedKeys = ['id', 'key', 'since', 'until', 'subject', 'all'];
+        const unallowedKeys = difference(Object.keys(queryBy), allowedKeys);
 
         if (unallowedKeys.length > 0) {
             throw new Error('Unallowed keys: ' + unallowedKeys);
         }
 
         // convert dates
-        if (check.date(deleteBy.since)) {
-            deleteBy.since = deleteBy.since.toISOString();
+        if (check.date(queryBy.since)) {
+            queryBy.since = queryBy.since.toISOString();
         }
 
-        if (check.date(deleteBy.until)) {
-            deleteBy.until = deleteBy.until.toISOString();
+        if (check.date(queryBy.until)) {
+            queryBy.until = queryBy.until.toISOString();
         }
 
-        return context.http.makeRequest({
-            method: 'DELETE',
-            url: `/v1/apps/${context.applicationId}/${ENDPT}?${querystring.stringify(deleteBy)}`
-        }, userOpts);
-    }
+        return {
+            // retrieve all queried events, returned as an array
+            // @param userOpts: option overrides for this request
+            // @return A promise that resolves to an array of event objects
+            getList: function(userOpts) {
+                // Doesn't apply for get
+                delete queryBy.all;
 
-    // deletes all events
-    // @param userOpts: option overrides for this request
-    // @returns Returns a promise that resolves to an object stating the number of deleted events
-    function removeAll(userOpts) {
+                let array = [];
+                let url = `/v1/apps/${context.applicationId}/${ENDPT}?${querystring.stringify(queryBy)}`;
 
-        return context.http.makeRequest({
-            method: 'DELETE',
-            url: `/v1/apps/${context.applicationId}/${ENDPT}?all=true`
-        }, userOpts);
+                function pageFn() {
+                    return context.http.makeRequest({ url }, userOpts).then(function(body) {
+                        array = array.concat(body.data || []); // concatinate the new data
+
+                        url = body.pages.next;
+                        if (url) {
+                            return pageFn();
+                        } else {
+                            return array;
+                        }
+                    });
+                }
+
+                return pageFn();
+            },
+            // retrieve all queried events, returned as an iterator
+            // @param userOpts: option overrides for this request
+            // @return An iterator that returns promises that resolve with the next event
+            getAll: function*(userOpts) {
+                // Doesn't apply for get
+                delete queryBy.all;
+
+                function pageFn() {
+                    let url = `/v1/apps/${context.applicationId}/${ENDPT}?${querystring.stringify(queryBy)}`;
+                    return function() {
+                        return context.http.makeRequest({ url }, userOpts).then(function(body) {
+                            url = body.pages.next;
+                            return body;
+                        });
+                    };
+                }
+
+                yield* pageToGenerator(pageFn());
+            },
+            // delete all queried events
+            // @param userOpts: option overrides for this request
+            // @returns Returns a promise that resolves to an object stating the number of deleted events
+            remove: function(userOpts) {
+                return context.http.makeRequest({
+                    method: 'DELETE',
+                    url: `/v1/apps/${context.applicationId}/${ENDPT}?${querystring.stringify(queryBy)}`
+                }, userOpts);
+            }
+        };
     }
 
     return {
-        get: obj.get,
-        getAll: obj.getAll,
         create: obj.create,
-        remove,
-        removeMultiple,
-        removeAll
+        query
     };
 };

--- a/src/http.js
+++ b/src/http.js
@@ -38,7 +38,7 @@ class BadgeUpHttp {
 
         // for internal unit tests
         if (options._payload) {
-            return options._payload(options);
+            return Promise.resolve(options._payload(options));
         }
 
         return got(options).then(function(response) {


### PR DESCRIPTION
New syntax:

```javascript
client.events.query()
    .key('mykey')
    .subject('bob')
    .getList() // getAll() or remove()
```