### PR TITLE
Implement job results

### DIFF
--- a/spec/jobResult.spec.js
+++ b/spec/jobResult.spec.js
@@ -1,0 +1,131 @@
+'use strict';
+
+require('co-mocha');
+
+const expect = require('chai').expect;
+const BadgeUp = require('./../');
+const bup = new BadgeUp({
+    applicationId: '1337',
+    apiKey: 'Co0kieMonst3r'
+});
+
+function generateFakeJobResult() {
+    return {
+        id: Math.floor(Math.random() * 1e6),
+        subject: 'kram',
+        key: 'event:key',
+        modifier: { '@inc': 5 },
+        timestamp: Date.now(),
+        options: null,
+        data: null
+    };
+}
+
+describe('job results', function() {
+    it('should get a single job result', function*() {
+        const jobResult = generateFakeJobResult();
+        function _payload() {
+            return {
+                pages: {
+                    previous: null,
+                    next: null
+                },
+                data: [jobResult]
+            };
+        }
+
+        function _validate(options) {
+            expect(options.url).to.equal(`/v1/apps/1337/jobresult?id=${jobResult.id}`);
+            expect(options.method).to.be.oneOf([undefined, 'GET']);
+            expect(options.headers).to.be.an('object');
+        }
+
+        const result = yield bup.jobResults.query().id(jobResult.id).getAll({ _payload, _validate });
+
+        expect(result).to.be.an('array');
+    });
+
+    it('should get all job results', function*() {
+        const jobResult = generateFakeJobResult();
+
+        function _payload(options) {
+            if (options.url.indexOf('PAGE_TWO') > 0) {
+                // last page of date
+                return Promise.resolve({
+                    pages: {
+                        previous: null,
+                        next: null
+                    },
+                    data: (new Array(10)).fill(jobResult)
+                });
+            } else {
+                // first page of data
+                return Promise.resolve({
+                    pages: {
+                        previous: null,
+                        next: '/v1/apps/1337/jobresult?after=PAGE_TWO'
+                    },
+                    data: (new Array(10)).fill(jobResult)
+                });
+            }
+        }
+
+        function _validate(options) {
+            if (options.url.indexOf('PAGE_TWO') > 0) {
+                expect(options.url).to.equal('/v1/apps/1337/jobresult?after=PAGE_TWO');
+            } else {
+                expect(options.url).to.equal('/v1/apps/1337/jobresult?');
+            }
+            expect(options.headers).to.be.an('object');
+        }
+
+        let count = 0;
+        for (let jobResult of bup.jobResults.query().getIterator({ _payload, _validate })) {
+            count++;
+            jobResult = yield jobResult;
+            expect(jobResult).to.be.an('object');
+        }
+
+        // total number of events
+        expect(count).to.equal(20);
+    });
+
+    it('should get multiple job results for a subject', function*() {
+        function _payload() {
+            return {
+                pages: {
+                    previous: null,
+                    next: null
+                },
+                data: []
+            };
+        }
+
+        function _validate(options) {
+            expect(options.url).to.equal(`/v1/apps/1337/jobresult?subject=100`);
+            expect(options.headers).to.be.an('object');
+        }
+
+        yield bup.jobResults.query().subject('100').getAll({ _payload, _validate });
+    });
+
+    it('should get multiple job results for a criterion ID', function*() {
+        function _payload() {
+            return {
+                pages: {
+                    previous: null,
+                    next: null
+                },
+                data: []
+            };
+        }
+
+        function _validate(options) {
+            expect(options.url).to.equal(`/v1/apps/1337/jobresult?criterionId=foo`);
+            expect(options.headers).to.be.an('object');
+        }
+
+        yield bup.jobResults.query().criterionId('foo').getAll({ _payload, _validate });
+    });
+
+});

--- a/spec/jobResult.spec.js
+++ b/spec/jobResult.spec.js
@@ -128,4 +128,23 @@ describe('job results', function() {
         yield bup.jobResults.query().criterionId('foo').getAll({ _payload, _validate });
     });
 
+    it('should sort multiple job results by ID', function*() {
+        function _payload() {
+            return {
+                pages: {
+                    previous: null,
+                    next: null
+                },
+                data: []
+            };
+        }
+
+        function _validate(options) {
+            expect(options.url).to.equal(`/v1/apps/1337/jobresult?sort=id%3Adesc`);
+            expect(options.headers).to.be.an('object');
+        }
+
+        yield bup.jobResults.query().sort('id', 'desc').getAll({ _payload, _validate });
+    });
+
 });

--- a/src/index.js
+++ b/src/index.js
@@ -41,6 +41,7 @@ class BadgeUp {
         this.metrics = require('./metrics')(this);
         this.events = require('./events')(this);
         this.progress = require('./progress')(this);
+        this.jobResults = require('./jobResults')(this);
     }
 }
 

--- a/src/jobResults/index.js
+++ b/src/jobResults/index.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const check = require('check-types');
+const collectQueryParams = require('../utils/collectQueryParams');
+const querystring = require('querystring');
+const pageToGenerator = require('../utils/pageToGenerator');
+
+const ENDPT = 'jobresult';
+
+const GET_QUERY_PARAMS = ['criterionId', 'subject', 'id', 'sort'];
+
+// Earned Achievements module
+// @param context: The context to make requests in. Basically, `this`
+module.exports = function earnedAchievements(context) {
+    class JobResultQueryBuilder {
+        constructor(context) {
+            this.context = context;
+        }
+
+        criterionId(criterionId) {
+            check.string(criterionId, 'criterionId must be a string');
+            this.criterionId = criterionId;
+            return this;
+        }
+
+        subject(subject) {
+            check.string(subject, 'subject must be a string');
+            this.subject = subject;
+            return this;
+        }
+
+        id(id) {
+            check.string(id, 'id must be a string');
+            this.id = id;
+            return this;
+        }
+
+        sort(key, direction) {
+            check.string(key, 'key must be a string');
+            check.string(direction, 'direction must be a string');
+            this.sort =`${key}:${direction}`;
+            return this;
+        }
+
+        // get all queried job results
+        // @param userOpts: option overrides for this request
+        // @returns Returns an iterator that returns promises that resolve with the next job result
+        *getIterator(userOpts) {
+            const queryBy = collectQueryParams(this, GET_QUERY_PARAMS);
+
+            function pageFn() {
+                let url = `/v1/apps/${context.applicationId}/${ENDPT}?${querystring.stringify(queryBy)}`;
+                return function() {
+                    return context.http.makeRequest({ url }, userOpts).then(function(body) {
+                        url = body.pages.next;
+                        return body;
+                    });
+                };
+            }
+
+            yield* pageToGenerator(pageFn());
+        }
+
+        // retrieve all queried job results, returned as an array
+        // @param userOpts: option overrides for this request
+        // @return A promise that resolves to an array of job results
+        getAll(userOpts) {
+            const queryBy = collectQueryParams(this, GET_QUERY_PARAMS);
+
+            let array = [];
+            let url = `/v1/apps/${context.applicationId}/${ENDPT}?${querystring.stringify(queryBy)}`;
+
+            function pageFn() {
+                return context.http.makeRequest({ url }, userOpts).then(function(body) {
+                    array = array.concat(body.data || []); // concatinate the new data
+
+                    url = body.pages.next;
+                    if (url) {
+                        return pageFn();
+                    } else {
+                        return array;
+                    }
+                });
+            }
+
+            return pageFn();
+        }
+    }
+
+    // Sets up a delete request targeting earned achievements using query filters
+    // @param queryBy: filters to query events by
+    // @returns Returns an instance of the JobResultQueryBuilder class
+    function query() {
+        return new JobResultQueryBuilder(context);
+    }
+
+    return {
+        query
+    };
+};


### PR DESCRIPTION
Allows users to query job results by `subject`, `id`, `criterionId` and to sort by a particular field.